### PR TITLE
Update 10.switch_fallthrough_fix_1.go

### DIFF
--- a/10.switch_fallthrough_fix_1.go
+++ b/10.switch_fallthrough_fix_1.go
@@ -1,4 +1,4 @@
-
+package main
 
 import "fmt"
 


### PR DESCRIPTION
fix go get: expected 'package', found 'import'
